### PR TITLE
Added pip requirements file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+# The requests 'security' extra prevents InsecurePlatformWarning
+# on e.g. Ubuntu 14.04 LTS
+
+anyjson>=0.3.3,<1
+futures>=3.0.3,<4
+requests[security]>=2.3.0,<3
+requests-futures>=0.9.5,<1


### PR DESCRIPTION
The requests 'security' extra prevents InsecurePlatformWarning on e.g. Ubuntu 14.04 LTS. Makes it easier to create a working virtualenv.
