### PR TITLE
made python3 compliant

### DIFF
--- a/PythonConfluenceAPI/__init__.py
+++ b/PythonConfluenceAPI/__init__.py
@@ -1,4 +1,12 @@
-__author__ = 'Robert Cope', 'Pushrod Technology'
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
-from api import ConfluenceAPI, all_of
-from cfapi import ConfluenceFuturesAPI
+from future import standard_library
+standard_library.install_aliases()
+
+__author__ = 'Robert Cope, Pushrod Technology'
+
+from .api import ConfluenceAPI, all_of
+from .cfapi import ConfluenceFuturesAPI

--- a/PythonConfluenceAPI/api.py
+++ b/PythonConfluenceAPI/api.py
@@ -1,9 +1,14 @@
+from __future__ import absolute_import
+import future.standard_library
+future.standard_library.install_aliases()
+
 __author__ = "Robert Cope"
 
 import sys
 import requests
 from requests.auth import HTTPBasicAuth
-from urlparse import urljoin
+from urllib.parse import urljoin
+
 import logging
 try:
     import anyjson as json
@@ -31,7 +36,7 @@ def all_of(api_call, *args, **kwargs):
     :param kwargs: Keyword arguments of the call.
     """
     kwargs = kwargs.copy()
-    pos, outer_limit = 0, kwargs.get('limit', 0) or sys.maxint
+    pos, outer_limit = 0, kwargs.get('limit', 0) or sys.maxsize
     while True:
         response = api_call(*args, **kwargs)
         for item in response.get('results', []):
@@ -805,9 +810,9 @@ class ConfluenceAPI(object):
                  or the results of the callback. Will raise requests.HTTPError on bad input, potentially.
         """
         if isinstance(attachments, list):
-            assert all(isinstance(at, dict) and "file" in at.keys() for at in attachments)
+            assert all(isinstance(at, dict) and "file" in list(at.keys()) for at in attachments)
         elif isinstance(attachments, dict):
-            assert "file" in attachments.keys()
+            assert "file" in list(attachments.keys())
         else:
             assert False
         return self._service_post_request("rest/api/content/{id}/child/attachment".format(id=content_id),
@@ -1034,7 +1039,7 @@ class ConfluenceAPI(object):
                  or the results of the callback. Will raise requests.HTTPError on bad input, potentially.
         """
         if isinstance(attachment, dict):
-            assert "file" in attachment.keys()
+            assert "file" in list(attachment.keys())
         else:
             assert False
         return self._service_post_request("rest/api/content/{content_id}/child/attachment/{attachment_id}/data"

--- a/PythonConfluenceAPI/cfapi.py
+++ b/PythonConfluenceAPI/cfapi.py
@@ -1,9 +1,13 @@
+from __future__ import absolute_import
+import future.standard_library
+future.standard_library.install_aliases()
+
 __author__ = 'Robert Cope'
 
 from requests.auth import HTTPBasicAuth
-from api import ConfluenceAPI, api_logger, json
+from .api import ConfluenceAPI, api_logger, json
 from requests_futures.sessions import FuturesSession
-from urlparse import urljoin
+from urllib.parse import urljoin
 
 
 # By default requests-futures request method returns the response object instead of the results of the callback;

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 # on e.g. Ubuntu 14.04 LTS
 
 anyjson>=0.3.3,<1
+future>=0.15.2
 futures>=3.0.3,<4
 requests[security]>=2.3.0,<3
 requests-futures>=0.9.5,<1

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
-__author__ = 'Robert Cope', 'Pushrod Technology'
+__author__ = 'Robert Cope, Pushrod Technology'
 __author_email__ = 'robert.cope@pushrodtechnology.com'
-__version__ = '0.0.1rc4'
+__version__ = '0.0.1rc6'
 
 import ez_setup
 ez_setup.use_setuptools()


### PR DESCRIPTION
This will solve #8 for python3 compliancy.

Tested code changes under both python 2 and 3 virtual environments.
- [future import](http://python-future.org/)  this will enforce python 2/3 compatibility to an extent
- [relative imports to a package](http://python-future.org/compatible_idioms.html#imports-relative-to-a-package)
- [alias urlparse to urllib.parse](http://python-future.org/compatible_idioms.html?highlight=urllib#urllib-module) 

I also bumped the version to 0.0.1rc6. I'm not sure if that's correct. The version I downloaded say 0.0.1rc4, though pip itself has rc5 in place. Tell me if it should change this and I will.

Test this out, let me know of any adjustments you'd like and I can do an amended PR.
