### PR TITLE
Adding 'wiki' representation for 'convert_contentbody_to_new_type'.

### DIFF
--- a/PythonConfluenceAPI/api.py
+++ b/PythonConfluenceAPI/api.py
@@ -1122,6 +1122,7 @@ class ConfluenceAPI(object):
         --------------------------------------------------------------
         "storage"               |   "view","export_view","editor"
         "editor"                |   "storage"
+        "wiki"                  |   "storage"
         "view"                  |   None
         "export_view"           |   None
 
@@ -1133,7 +1134,7 @@ class ConfluenceAPI(object):
         :return: The JSON data returned from the contentbody/convert/{to} endpoint,
                  or the results of the callback. Will raise requests.HTTPError on bad input, potentially.
         """
-        assert {old_representation, new_representation} < {"storage", "editor", "view", "export_view"}
+        assert {old_representation, new_representation} < {"storage", "editor", "view", "export_view", "wiki"}
         # TODO: Enforce conversion rules better here.
         request_data = {"value": str(content_data), "representation": old_representation}
         return self._service_post_request("rest/api/contentbody/convert/{to}".format(to=new_representation),


### PR DESCRIPTION
The Confluence REST API seemingly supports converting from wiki format to (at least) their storage format. However, the function `convert_contentbody_to_new_type` disallows old_representation to be `'wiki'`, as it looks like it was taken from their docs directly.

I have tested this locally with 2.7.10 and 3.5.2, and on my Confluence Server 5.10.1 it correctly returns the storage format.

See the [Confluence Dev Content Conversion](https://developer.atlassian.com/confdev/confluence-server-rest-api/confluence-rest-api-examples#ConfluenceRESTAPIExamples-Contentconversion) examples for the suggested usage.